### PR TITLE
Minor cleanup of project configuration

### DIFF
--- a/GravityTurn/GravityTurn/GravityTurn.csproj
+++ b/GravityTurn/GravityTurn/GravityTurn.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <KSP_Dir>$(MSBuildStartupDirectory)/../Kerbal Space Program</KSP_Dir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,28 +36,28 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(KSP_Dir)/KSP_Data/Managed/Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>$(KSP_Dir)/KSP_Data/Managed/Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Condition="'$(Configuration)' == 'Debug'" Include="KramaxReloadExtensions">
-      <HintPath>..\..\..\..\..\Games\Kerbal Space Program\KSP Dev 1.2\GameData\KramaxPluginReload\Plugins\KramaxReloadExtensions.dll</HintPath>
+      <HintPath>$(KSP_Dir)/GameData/KramaxPluginReload/Plugins/KramaxReloadExtensions.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="KSPAssets">
-      <HintPath>..\..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\KSPAssets.dll</HintPath>
+      <HintPath>$(KSP_Dir)/KSP_Data/Managed/KSPAssets.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(KSP_Dir)/KSP_Data/Managed/UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(KSP_Dir)/KSP_Data/Managed/UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -96,15 +97,18 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>mkdir "$(SolutionDir)\..\GameData\GravityTurn\Plugins\"
-copy /Y "$(TargetPath)" "$(SolutionDir)\..\GameData\GravityTurn\Plugins\"
-copy /Y "$(SolutionDir)\..\LICENSE" "$(SolutionDir)\..\GameData\GravityTurn\"</PostBuildEvent>
+      <OutputDir>$(SolutionDir)\..\GameData\GravityTurn</OutputDir>
   </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="AfterBuild">
+    <MakeDir Directories="$(OutputDir)\Plugins\"/>
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(OutputDir)\Plugins\"/>
+    <Copy SourceFiles="$(SolutionDir)\..\LICENSE" DestinationFolder="$(OutputDir)"/>
+  </Target>
 </Project>


### PR DESCRIPTION
The plugin references the KSP directory on the original developer's
system.  I added a configuration variable for the KSP directory which
allows developers to use symbolic links to connect their KSP directory
without hard-coding personal values.  I used forward slashes which
should work on both Windows and Linux.

I also replaced the explicit mkdir and copy commands with MSBuild tasks
which work on both Windows and Linux.